### PR TITLE
Fix the sql eror caused by pwg_log due the use of $page['section']

### DIFF
--- a/include/functions.inc.php
+++ b/include/functions.inc.php
@@ -10,7 +10,7 @@ function contact_form_section_init()
 
   if ($tokens[0] == 'contact')
   {
-    $page['section'] = 'contact';
+    $page['sectionstring'] = 'contact';
     $page['title'] = l10n('Contact');
     $page['body_id'] = 'theContactPage';
     $page['is_external'] = true;
@@ -30,7 +30,7 @@ function contact_form_page()
 {
   global $page;
 
-  if (isset($page['section']) && $page['section'] == 'contact')
+  if (isset($page['sectionstring']) && $page['sectionstring'] == 'contact')
   {
     include(CONTACT_FORM_PATH . 'include/contact_form.inc.php');
   }


### PR DESCRIPTION
Some older - not maintained - plugins are writing $page['section']. Contactform does this as well. 

the Piwigo pwg_log function just checks isset($page['section']) and attempts to create an entry in the history table. It seems database column section of that table was turned into enum. Now the plugin sets $page['section'}='contact'. pwg_log make the insert, but 'contact' is not part of the allowed collection for the enum column. So you get

Warning:  [mysql error 1265] Data truncated for column 'section' at row 1

INSERT INTO piwigo_history
  (
    date,
    time,
    user_id,
    IP,
    section,
    category_id,
    image_id,
    image_type,
    format_id,
    auth_key_id,
    tag_ids
  )
  VALUES
  (
    CURRENT_DATE,
    CURRENT_TIME,
    2,
    '192.168.0.22',
    'guestbook',
    NULL,
    NULL,
    NULL,
    NULL,
    NULL,
    NULL
  )
; in /media/sf_piwigo/include/dblayer/functions_mysqli.inc.php on line 845

In my opinion there are 3 solutions possible:

1.) (my favorite)
Someone out of the core team rwrites pwg_log so it checks if the given section value is valid, and nulls it if the check fails

2.) The core team allows plugin developers to add values to the collection for the enum column. I feel this could turn into a nightmare

3.) a dirty hack like the given one, where plugin developers just avoid using the section var out of the given range. Downside: every plugin developer that was adding own stuff on $page['section]=='contact', will have to rewrite his stuff.

This is why 1.) is my absolute favorite, beside a better documentation for plugin developers ;)

Cheers,
Peter